### PR TITLE
Add option to find stems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+blinky.cfg

--- a/blinky.py
+++ b/blinky.py
@@ -32,3 +32,7 @@ class Blinky:
         member = self.ldap.member(net_id=net_id)
         if member['duDukeID']:
             return self.grouper.group_add_member(group_name, member['duDukeID'])
+
+    def stems(self, stem_name):
+        stems = self.grouper.stems(stem_name)
+        return [stem['name'] for stem in stems['stemResults']]

--- a/blinky_go.py
+++ b/blinky_go.py
@@ -20,6 +20,9 @@ def __main__():
     member_arg = argparse.ArgumentParser(add_help=False)
     member_arg.add_argument('net_id', help='is Duke net id to use')
 
+    stem_arg = argparse.ArgumentParser(add_help=False)
+    stem_arg.add_argument('stem_name', help='Stem Name (e.g. abc:def)')
+
     subparsers = parser.add_subparsers(help='sub-command help')
 
     subparsers.add_parser('group_members',
@@ -45,6 +48,12 @@ def __main__():
                           parents=[common_args, group_arg, member_arg],
                           formatter_class=argparse.ArgumentDefaultsHelpFormatter
                           ).set_defaults(func=group_add_member)
+
+    subparsers.add_parser('find_stems',
+                          help='Find stems matching a name',
+                          parents=[common_args, stem_arg],
+                          formatter_class=argparse.ArgumentDefaultsHelpFormatter
+                          ).set_defaults(func=find_stems)
 
     args = parser.parse_args()
 
@@ -81,5 +90,9 @@ def group_delete_member(duke_blinky, args):
 def group_add_member(duke_blinky, args):
     print duke_blinky.group_add_member(args.group_name, args.net_id)
 
+
+def find_stems(duke_blinky, args):
+    for stem_name in duke_blinky.stems(args.stem_name):
+        print stem_name
 
 __main__()

--- a/grouper_ws.py
+++ b/grouper_ws.py
@@ -49,6 +49,10 @@ class GrouperWS:
     def group_add_member(self, group_name, duke_id):
         return self.ws_put('/groups/' + group_name + '/members/' + duke_id, 'WsAddMemberLiteResult')
 
+    def stems(self, stem_name):
+        query = '?wsLiteObjectType=WsRestFindStemsLiteRequest&stemName={}&stemQueryFilterType={}'.format(stem_name, 'FIND_BY_STEM_NAME_APPROXIMATE')
+        return self.ws_get('/stems' + query, 'WsFindStemsResults')
+
     def group_members_subjects(self, group_name):
         subjects = []
         members = self.group_members(group_name)


### PR DESCRIPTION
Uses approximate name matching, e.g

blinky_go.py find_stems unix

matches

org:subtree:UNIX